### PR TITLE
Remote improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ All variables which can be overridden are stored in defaults/main.yml file as we
 
 | Name | Default value | Description |
 | ------ | ------ | ----- |
-| `backup_server` | `"{{ groups['backupservers'] \| first }}"` | Inventory hostname of the machine running the backup server (where the backup clients shall send their backup to). Used to correctly set the SSH key comment |
 | `restic_server_user` | rest-server | User to run 'rest-server' as. Will also own `restic_server_backup_path` |
 | `restic_server_group` | rest-server | Group to run 'rest-server' as. Will also own `restic_server_backup_path` |
 | `restic_server_backup_path` | /opt/restic | The directory to store all encrypted backups and the `.htaccess` file. |
@@ -48,8 +47,8 @@ Built for `rest-server` version `0.10.0` and above (relies on the `--version` op
 
   vars:
     restic_server_tls_enable: true
-    restic_server_tls_cert: "/etc/letsencrypt/live/{{ backup_server }}/fullchain.pem"
-    restic_server_tls_key: "/etc/letsencrypt/live/{{ backup_server }}/privkey.pem"
+    restic_server_tls_cert: "/etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem"
+    restic_server_tls_key: "/etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem"
 
   roles:
   - role: restic_server

--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 This role installs `rest-server` ([see here for sourcecode](https://github.com/restic/rest-server)), an HTTP REST server for restic clients with additional authentication and TLS support. All users from the password-store are registered in the `.htpasswd` file (append only so far).
 
 # Requirements
-* A trusted SSL certificate is required (we use Let's Encrypt). If it is not trusted (e.g. self-signed), restic clients must be run with the additional flag `--cacert` (not yet implemented).
+* If using SSL certificates, it must exist before this role is applied (otherwise, starting the server will fail). If it is a self-signed certificate, restic clients must be run with the additional flag `--cacert` (not yet implemented).
   * SSL certificates must be accessible by user `rest-server`.
+  * If no SSL certificate is used, make sure to template clients with `rest:http://`.
 * Installation is currently only supported for x86_64 architecture.
 * Installation is currently only supported on Linux distributions using systemd.
-* [pass](https://www.passwordstore.org/) installed on the Ansible runner and configured for password storage. ([See example configuration](https://www.fifty2.eu/innovation/how-we-provide-i-t-secrets-through-passwordstore-in-ansible-at-fifty2/)) Backup encryption password and REST authentication password creation are the backup client's concern (done in `restic_client` role).
+* Depending on how you store client REST passwords, you might want to deploy those automatically.
+  * REST authentication passwords are not deployed automatically to the server by this role by default.
+  * Example: Install [pass](https://www.passwordstore.org/) on the Ansible runner and configure for password storage. See `tasks/add_rest_accounts.yml` for example, and ([see example configuration](https://www.fifty2.eu/innovation/how-we-provide-i-t-secrets-through-passwordstore-in-ansible-at-fifty2/)).
+  * Other example: See "default" molecule scenario in `restic_remote` role. It stores REST passwords in `host_vars` and deploys them in a similar way as the example above.
+  * Backup encryption password and REST authentication password (through custom REST repository template) creation are the backup client's concern (done in `restic_client` role).
 
 ## Remote backup clients
-The server is capable of connecting to restic clients via SSH, if they can't reach the backup server directly, and trigger backup jobs there. This feature is described in further detail in the [`restic_remote` README](https://github.com/FIFTY2Technology/ansible-role-restic_remote/blob/main/README.md). This role configures only basic requirements for this functionality.
+The server is capable of connecting to restic clients via SSH, if they can't reach the backup server directly, and trigger backup jobs there. This feature is described in further detail in the [`restic_remote` README](https://github.com/FIFTY2Technology/ansible-role-restic_remote/blob/main/README.md). This role configures basic requirements for this functionality, but this doesn't influence "normal" operation in case you choose to not deploy any remote backup clients.
 
 # Role Variables
 All variables which can be overridden are stored in defaults/main.yml file as well as in table below.
@@ -33,14 +38,16 @@ For all other variables, see the roles `defaults/main.yml` and check `host_vars/
 Built for `rest-server` version `0.10.0` and above (relies on the `--version` option).
 
 # Example Playbook
+Deploy server with HTTP and no users:
 ```
 - hosts: backupservers
   gather_facts: true
 
   roles:
-  - role: restic_server
+    - role: fifty2technology.restic_server
 ```
 
+Deploy server with HTTPS (certificates must exist):
 ```
 - hosts: backupservers
   gather_facts: true
@@ -51,6 +58,29 @@ Built for `rest-server` version `0.10.0` and above (relies on the `--version` op
     restic_server_tls_key: "/etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem"
 
   roles:
-  - role: restic_server
+    - role: fifty2technology.restic_server
 ```
 
+Deploy server with HTTP and add clients based on Ansible group membership, get REST passwords from somewhere (e.g. `host_vars` pointing to Ansible Vault):
+```
+- hosts: backupservers
+  gather_facts: true
+
+  roles:
+    - role: fifty2technology.restic_server
+
+  post_tasks:
+    - name: Add rest-server accounts
+      community.general.htpasswd:
+        path: "{{ restic_server_backup_path }}/.htpasswd"
+        name: "{{ item.inventory_hostname | regex_replace('\\.', '_') }}"
+        password: "{{ item.our_rest_password }}"
+        crypt_scheme: bcrypt
+        state: present
+        owner: "{{ restic_server_user }}"
+        group: "{{ restic_server_group }}"
+        mode: '0600'
+      become: true
+      loop: "{{ groups['backupclients'] }}"
+```
+See `tasks/add_rest_accounts.yml` for another, similar example.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All variables which can be overridden are stored in defaults/main.yml file as we
 | `restic_server_version` | latest | Specify a release version to download from GitHub. Release versions must not include the leading `v` as tagged on GitHub. E.g. `0.10.0`. See: https://github.com/restic/rest-server/releases Default: 'latest' |
 | `restic_server_binary_install_dir` | "" | Provide a full path to a local directory (on the Ansible controller) where the `rest-server` binary is available, e.g. for deploying self-compiled versions. Binary must be named 'rest-server' inside this directory. |
 | `restic_server_listen_address` | 0.0.0.0 | The default address for rest-server to listen for incoming clients |
-| `restic_server_listen_port` | 3000 | The default port for rest-server to listen for incoming clients |
+| `restic_server_listen_port` | 3000 | The default port for rest-server to listen for incoming clients. If you plan to deploy `fifty2technology.restic_remote` to clients, `restic_server_listen_port` must be defined in a place where clients can read it, e.g. group_vars/all. |
 | `restic_server_tls_enable` | false | Wheather to enable TLS support or not (default: not) |
 | `restic_server_tls_cert` | - | Absolute path to TLS certificate |
 | `restic_server_tls_key` | - | Absolute path to TLS key |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ This role installs `rest-server` ([see here for sourcecode](https://github.com/r
 * [pass](https://www.passwordstore.org/) installed on the Ansible runner and configured for password storage. ([See example configuration](https://www.fifty2.eu/innovation/how-we-provide-i-t-secrets-through-passwordstore-in-ansible-at-fifty2/)) Backup encryption password and REST authentication password creation are the backup client's concern (done in `restic_client` role).
 
 ## Remote backup clients
-The server is capable of connecting to restic clients via SSH if they can't reach the backup server directly, and trigger backup jobs there. This feature is described in further detail in the `restic_remote` README file.
-
-To allow the server to login on clients via SSH, it is necessary to specify the SSH public key of the server as variable `restic_remote_server_authorized_key`. The key is shown by the `Print SSH public key - See README file for usage of this key` task when running this role. This variable must be accessible to (at least) all remote backup clients (e.g. via `group_vars/remoteclients.yml`) and is necessary for the `restic_remote` role to work correctly.
+The server is capable of connecting to restic clients via SSH, if they can't reach the backup server directly, and trigger backup jobs there. This feature is described in further detail in the [`restic_remote` README](https://github.com/FIFTY2Technology/ansible-role-restic_remote/blob/main/README.md). This role configures only basic requirements for this functionality.
 
 # Role Variables
 All variables which can be overridden are stored in defaults/main.yml file as well as in table below.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,10 @@ restic_server_binary_install_dir: ""
 restic_server_backup_path: /opt/restic
 
 ###
-# The default address and port for rest-server to listen for incoming clients
+# The default address and port for rest-server to listen for incoming clients.
+# If you plan to deploy 'fifty2technology.restic_remote' to clients,
+# 'restic_server_listen_port' must be defined in a place where clients can
+# read it, e.g. group_vars/all.
 ###
 restic_server_listen_address: 0.0.0.0
 restic_server_listen_port: 3000

--- a/molecule/custom_user_group/converge.yml
+++ b/molecule/custom_user_group/converge.yml
@@ -5,7 +5,6 @@
   become: false
 
   vars:
-    backup_server: "{{ inventory_hostname }}"
     restic_server_user: lololol
     restic_server_group: backup
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,9 +4,6 @@
   gather_facts: true
   become: false
 
-  vars:
-    backup_server: "{{ inventory_hostname }}"
-
   tasks:
     - name: "Include ansible-role-restic_server"
       ansible.builtin.include_role:

--- a/molecule/local_bin/converge.yml
+++ b/molecule/local_bin/converge.yml
@@ -3,7 +3,6 @@
   hosts: all
 
   vars:
-    backup_server: "{{ inventory_hostname }}"
     restic_server_local_bin_dir: /tmp
 
   tasks:

--- a/molecule/specific_version/converge.yml
+++ b/molecule/specific_version/converge.yml
@@ -4,7 +4,6 @@
   gather_facts: true
 
   vars:
-    backup_server: "{{ inventory_hostname }}"
     restic_server_version: "0.10.0"
 
   tasks:

--- a/tasks/add_rest_accounts.yml
+++ b/tasks/add_rest_accounts.yml
@@ -37,6 +37,3 @@
     label: "{{ item | basename | splitext | first | regex_replace('\\.', '_') }}"
   notify: Reload rest-server
   become: true
-
-#- name: Ensure that rest-server loads the new .htpasswd file
-#  ansible.builtin.meta: flush_handlers

--- a/tasks/add_rest_accounts.yml
+++ b/tasks/add_rest_accounts.yml
@@ -11,8 +11,8 @@
 ###
 # This tasks file ensures all auth credentials in the password-store are also
 # present in the backup servers '.htpasswd' file.
-# NOTE: Creating such credentials is the concern of the 'restic_client' role
-# (for automatically installed backup clients).
+# NOTE: Creating such credentials is the concern of a custom REST repository
+# template in 'restic_client' role.
 # For machines, we use the clients hostname as username for authentication, but
 # the .htpasswd file specification does not allow dots in usernames, therefore
 # we change them to '_' here.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,3 @@
 
 - name: Import tasks file prepare_for_remote_clients.yml
   ansible.builtin.import_tasks: prepare_for_remote_clients.yml
-
-- name: Import tasks file add_rest_accounts.yml
-  ansible.builtin.import_tasks: add_rest_accounts.yml

--- a/tasks/prepare_for_remote_clients.yml
+++ b/tasks/prepare_for_remote_clients.yml
@@ -19,7 +19,7 @@
 - name: Create an SSH keypair on the server
   community.crypto.openssh_keypair:
     path: "/home/{{ restic_server_user }}/.ssh/id_ed25519"
-    comment: "{{ restic_server_user }}@{{ backup_server }}"
+    comment: "{{ restic_server_user }}@{{ inventory_hostname }}"
     type: ed25519
     owner: "{{ restic_server_user }}"
     group: "{{ restic_server_group }}"

--- a/tasks/prepare_for_remote_clients.yml
+++ b/tasks/prepare_for_remote_clients.yml
@@ -27,13 +27,6 @@
   register: _server_ssh_key
 
 ###
-# This is the tasks that is referenced in the README
-###
-- name: Print SSH public key - See README file for usage of this key
-  ansible.builtin.debug:
-    msg: "{{ _server_ssh_key.public_key }} {{ _server_ssh_key.comment }}"
-
-###
 # To let different hosts (clients) have distinct usernames to connect as (from
 # server to client), this folder will provide a systemd 'EnvironmentFile' for each
 # remote host with the respective SSH options. Variables will be consumed by all

--- a/tasks/prepare_for_remote_clients.yml
+++ b/tasks/prepare_for_remote_clients.yml
@@ -11,10 +11,10 @@
 
 ###
 # Make sure the backup server is prepared to connect to remote clients
-# This key is later read from the 'restic_remote_server_authorized_key' variable
-# by the 'restic_remote' role for clients to store it in their '.ssh/authorized_keys',
-# so that remote clients allow incoming SSH connections by the backup server.
-# See this role's and the 'restic_remote' role's README files for more infos.
+# This key is later read by the 'restic_remote' role for clients to store it in
+# their '.ssh/authorized_keys', so that remote clients allow incoming SSH
+# connections by the backup server.
+# See the 'fifty2technology.restic_remote' role's README files for more infos.
 ###
 - name: Create an SSH keypair on the server
   community.crypto.openssh_keypair:
@@ -35,8 +35,8 @@
 
 ###
 # To let different hosts (clients) have distinct usernames to connect as (from
-# server to client), this folder will provide an 'EnvironmentFile' for each
-# remote host with the respective SSH user. Variables will be consumed by all
+# server to client), this folder will provide a systemd 'EnvironmentFile' for each
+# remote host with the respective SSH options. Variables will be consumed by all
 # systemd services starting with 'restic-remote-'. The exact behaviour for
 # loading '.conf' files is described here (although we manually load '.env'
 # files instead), search for 'drop-in':
@@ -52,7 +52,18 @@
     mode: '0755'
   become: true
 
-- name: Create systemd service template for remote backup, -prune and -exporter
+###
+# Without any remote backup clients configured, these templated systemd services
+# remain without function on the server. Only if a remote backup client is
+# deployed via the 'fifty2technology.restic_remote' role, templated instances of
+# these services will get activated.
+# Templated instances are enabled and started selectively per host, depending on
+# whether the "original" service already exists on the remote client. E.g. if
+# there is no 'restic-exporter.service' found on the client, it will not activate
+# a 'restic-remote-exporter@<backup-client>.timer' on the backup server.
+# Also see 'fifty2technology.restic_remote' 'tasks/preflight.yml'.
+###
+- name: Create systemd service templates for remote backup, -prune and -exporter
   ansible.builtin.template:
     src: "{{ item }}.j2"
     dest: "/etc/systemd/system/{{ item }}"

--- a/templates/restic-remote-backup@.service.j2
+++ b/templates/restic-remote-backup@.service.j2
@@ -12,6 +12,7 @@ EnvironmentFile=/etc/systemd/system/restic-remote-@.service.d/%i.env
 ExecStart=/usr/bin/ssh \
 	%i \
 	-l ${SSH_USER} \
+	-p ${SSH_PORT} \
 	-R ${SSH_REMOTE_LISTEN_PORT}:localhost:{{ restic_server_listen_port }} \
 	-T \
 	/usr/bin/sudo /bin/systemctl start restic-backup.service


### PR DESCRIPTION
Add possibility to specify the SSH port that the backup server should dial when connecting to the remote backup client.
Extended comments and docs while working on `restic_client` and `restic_remote` in parallel. (see https://github.com/FIFTY2Technology/ansible-role-restic_remote/pull/1 and https://github.com/FIFTY2Technology/ansible-role-restic_client/pull/4